### PR TITLE
setup dayjs

### DIFF
--- a/src/components/templates/event/EventCard.tsx
+++ b/src/components/templates/event/EventCard.tsx
@@ -8,6 +8,7 @@ import { Divider } from '@mui/material'
 import IconButton from '@mui/material/IconButton'
 import ShareIcon from '@mui/icons-material/Share'
 import WifiIcon from '@mui/icons-material/Wifi'
+import { dayjs } from '../../../../store/date'
 
 interface EventProps {
   props: EventAttrs
@@ -16,18 +17,7 @@ interface EventProps {
 export default function EventCard(props: EventProps): JSX.Element {
   const { name, startsAt, endsAt, thumbnailImageUrl, timezone, online } =
     props.props
-  const options: Intl.DateTimeFormatOptions = {
-    dateStyle: 'full',
-    timeStyle: 'short',
-    timeZone: timezone,
-  }
-
-  const startTime = new Intl.DateTimeFormat('en-US', options).format(
-    new Date(startsAt)
-  )
-  const endTime = new Intl.DateTimeFormat('en-US', options).format(
-    new Date(endsAt)
-  )
+  const format = 'dddd, D MMMM, YYYY hh:mm A'
 
   return (
     <Card>
@@ -42,7 +32,10 @@ export default function EventCard(props: EventProps): JSX.Element {
           {name}
         </Typography>
         <Typography variant="body1" color="text.secondary">
-          {startTime} to {endTime} ({timezone})
+          {dayjs(startsAt).tz(timezone).format(format)} to{' '}
+          {dayjs(endsAt)
+            .tz(timezone)
+            .format(format + ' (zzz)')}{' '}
         </Typography>
         {online && (
           <Typography variant="body1" color="text.secondary">

--- a/store/date.ts
+++ b/store/date.ts
@@ -1,10 +1,12 @@
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
 import timezone from 'dayjs/plugin/timezone'
+import advancedFormat from 'dayjs/plugin/advancedFormat'
 import create from 'zustand'
 
 dayjs.extend(utc)
 dayjs.extend(timezone)
+dayjs.extend(advancedFormat)
 
 type timezoneState = {
   localTimezone: string
@@ -17,3 +19,5 @@ export const useTimezone = create<timezoneState>((set) => ({
   defaultTimezone: 'Asia/Singapore',
   setTimezone: (localTimezone) => set({ localTimezone }),
 }))
+
+export { dayjs }


### PR DESCRIPTION
Fixes #328 

Timezones are in full format, as abbreviated formats are not supported by the dayjs library.
See here:- https://github.com/iamkun/dayjs/issues/1154

![Screenshot 2022-02-28 at 11-39-26 Screenshot](https://user-images.githubusercontent.com/42090582/155933487-cf9cdc41-bd49-40f5-bebb-a9b4215a65af.png)
